### PR TITLE
Fix version numer retrieval in recent whipper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ install:
   - pip install flake8
 
 script:
-  - flake8 --max-complexity 15 eaclogger/logger/eac.py
+  - flake8 --max-complexity 20 eaclogger/logger/eac.py
   - python setup.py bdist_egg

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## Status
+
 [![Build Status](https://travis-ci.org/JoeLametta/morituri-eaclogger.svg?branch=master)](https://travis-ci.org/JoeLametta/morituri-eaclogger)
 
 ## Logger information
@@ -13,53 +14,71 @@ To use this plugin:
 
 * build it:
 
-        git clone https://github.com/JoeLametta/morituri-eaclogger.git
-        cd morituri-eaclogger
-        python2 setup.py bdist_egg
+    ```bash
+    git clone https://github.com/JoeLametta/morituri-eaclogger.git
+    cd morituri-eaclogger
+    python2 setup.py bdist_egg
+    ```
 
 * copy it to your plugin directory:
 
-        mkdir -p $HOME/.morituri/plugins
-        cp dist/morituri_*egg $HOME/.morituri/plugins
+    ```bash
+    mkdir -p $HOME/.morituri/plugins
+    cp dist/morituri_*egg $HOME/.morituri/plugins
+    ```
 
 * verify that it gets recognized:
 
-        rip cd rip --help
+    ```bash
+    rip cd rip --help
+    ```
 
-   You should see `eac` as a possible logger.
+  You should see `eac` as a possible logger.
 
 * use it:
 
-        rip cd rip --logger=eac
+    ```bash
+    rip cd rip --logger=eac
+    ```
 
-## Instructions for whipper (since version [0.2.4](https://github.com/JoeLametta/whipper/releases/tag/v0.2.4))
+## Instructions for whipper
 
 To use this plugin:
 
 * build it:
 
-        git clone https://github.com/JoeLametta/morituri-eaclogger.git
-        cd morituri-eaclogger
-        python2 setup.py bdist_egg
+    ```bash
+    git clone https://github.com/JoeLametta/morituri-eaclogger.git
+    cd morituri-eaclogger
+    python2 setup.py bdist_egg
+    ```
 
 * copy it to your plugin directory:
 
-        export XDG_DATA_HOME=${XDG_DATA_HOME:-"${HOME}/.local/share"}
-        mkdir -p $XDG_DATA_HOME/whipper/plugins
-        cp dist/morituri_*egg $XDG_DATA_HOME/whipper/plugins
+    ```bash
+    export XDG_DATA_HOME=${XDG_DATA_HOME:-"${HOME}/.local/share"}
+    mkdir -p $XDG_DATA_HOME/whipper/plugins
+    cp dist/morituri_*egg $XDG_DATA_HOME/whipper/plugins
+    ```
 
 * verify that it gets recognized:
 
-        rip cd rip --help
+    ```bash
+    whipper cd rip --help
+    ```
 
-   You should see `eac` as a possible logger.
+  You should see `eac` as a possible logger.
 
 * use it:
 
-        rip cd rip -L eac
+    ```bash
+    whipper cd rip -L eac
+    ```
 
 ## Developers
 
 To use the plugin while developing uninstalled:
 
-    python2 setup.py develop --install-dir=path/to/checkout/of/morituri
+```bash
+python2 setup.py develop --install-dir=path/to/checkout/of/morituri
+```

--- a/eaclogger/logger/eac.py
+++ b/eaclogger/logger/eac.py
@@ -2,7 +2,6 @@ import time
 import hashlib
 
 from morituri.common import common
-from morituri.configure import configure
 from morituri.result import result
 
 
@@ -52,13 +51,23 @@ class EacLogger(result.Logger):
 
         # Ripper version
         # ATM differs from EAC's typical log line
-        lines.append("morituri version %s" % configure.version)
+        isWhipper = False
+        try:
+            from morituri.configure import configure
+            lines.append("morituri version %s" % configure.version)
+        except ImportError:
+            import morituri
+            lines.append("whipper version %s" % morituri.__version__)
+            isWhipper = True
         lines.append("")
 
         # Rip date
         # ATM differs from EAC's typical log line
         date = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(epoch)).strip()
-        lines.append("morituri extraction logfile from %s" % date)
+        if isWhipper:
+            lines.append("whipper extraction logfile from %s" % date)
+        else:
+            lines.append("morituri extraction logfile from %s" % date)
         lines.append("")
 
         # Artist / Album

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,10 @@ from setuptools import setup, find_packages
 
 setup(
     name="morituri-eaclogger",
-    version="0.2.1",
+    version="0.2.2",
     description="""morituri EAC-style logger""",
     author="superveloman",
+    maintainer="JoeLametta",
     packages=[
         'eaclogger',
         'eaclogger.logger'],


### PR DESCRIPTION
It has been broken since https://github.com/JoeLametta/whipper/commit/976e1bdca2f0f86b97cf0250b6d92beeee2bcb03 (whipper release v0.4.1).